### PR TITLE
Add CI Test Job to Check if the Plugin Works Correctly

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,29 @@
+name: Test running the QGIS Plugin
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: |
+          pip3 install -r requirements.txt
+
+      - name: Install QGIS Python Lib
+        run: |
+          sudo apt-get install gpgconf gpg software-properties-common
+          sudo wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-qgis python3-pyqt5
+
+      - name: Run pytest
+        run: |
+          # Make sure Python knows about the QGIS libraries
+          pip3 install pytest
+          export PYTHONPATH=/usr/lib/python3/dist-packages/
+          python -m pytest

--- a/__init__.py
+++ b/__init__.py
@@ -13,15 +13,16 @@ def classFactory(iface):  # noqa: N802
             continue
 
         raise ImportError(
-        f"The dependency {pkg_dependency} for the OpenDRIVE Viewer "
-        "is not installed. "
-        "There are two ways to resolve this: "
-        "(1) install the 'qpip' plugin, restart QGIS, and "
-        "re-active the OpenDRIVE Viewer plugin. "
-        "(2) manually install the dependencies using: "
-        f"\"[QGIS_DIR]\\python-qgis.bat -m pip install -r {Path.home()}\\AppData\\Roaming\\QGIS\\QGIS3\\profiles\\"
-        "default\\python\\plugins\\odrviewer\\requirements.txt\""
+            f"The dependency {pkg_dependency} for the OpenDRIVE Viewer "
+            "is not installed. "
+            "There are two ways to resolve this: "
+            "(1) install the 'qpip' plugin, restart QGIS, and "
+            "re-active the OpenDRIVE Viewer plugin. "
+            "(2) manually install the dependencies using: "
+            f'"[QGIS_DIR]\\python-qgis.bat -m pip install -r {Path.home()}\\AppData\\Roaming\\QGIS\\QGIS3\\profiles\\'
+            'default\\python\\plugins\\odrviewer\\requirements.txt"'
         )
 
     from .odrviewer_plugin import OpenDriveViewer
+
     return OpenDriveViewer(iface)

--- a/test/main_test.py
+++ b/test/main_test.py
@@ -3,12 +3,14 @@ from pathlib import Path
 
 from odrviewer.converter.convert_odr_to_qgis import load_odr_map
 
+FIXTURE_DIR = Path(__file__).parent.parent.resolve()
 
-def main_test() -> None:
-    """Loads a sample OpenDRIVE file, and checks if the conversion code doesn't crash."""
-    load_odr_map(Path(r"./odrviewer/sample_files/Town04.xodr"))
+
+def test_loading_sample_odr_file():
+    """This test case loads a sample OpenDRIVE map."""
+    load_odr_map(FIXTURE_DIR / "sample_files" / "Town04.xodr")
 
 
 if __name__ == "__main__":
     """Helper `main` when running this file in the debugger."""
-    main_test()
+    load_odr_map(Path(r"./odrviewer/sample_files/Town04.xodr"))


### PR DESCRIPTION
This PR creates an unit test, that simulates the QGIS plugin loading of an OpenDRIVE map. The test passes if the plugin doesn't crash.